### PR TITLE
bump: Upgrade base image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@2.0.1
-  codacy_plugins_test: codacy/plugins-test@0.15.4
+  codacy: codacy/base@9.3.5
+  codacy_plugins_test: codacy/plugins-test@1.1.1
 
 workflows:
   version: 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/powershell:7.1.5-ubuntu-20.04
-LABEL maintainer="Aditya Patwardhan <adityap@microsoft.com>"
+FROM mcr.microsoft.com/powershell:lts-7.2-alpine-3.14
+LABEL maintainer="Codacy <code@codacy.com>"
 COPY docs /docs
 COPY runTool.ps1 /runTool.ps1
-RUN useradd -ms /bin/bash -u 2004 docker
+RUN adduser -D -u 2004 docker
 USER docker
 COPY psscriptanalyzer.version /
 RUN pwsh -c "Install-Module PSScriptAnalyzer -RequiredVersion $(tr -d '\n' < /psscriptanalyzer.version) -Force -Confirm:\$false"


### PR DESCRIPTION
Bumping base image to remove vulnerabilities. Using alpine because it is small and seems to work equally well, and is also totally free of vulnerabilities while even the latest ubuntu image has several medium severity issues.