### PR TITLE
fix: Use shell instead of sbt to publish docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ workflows:
           run_multiple_tests: true
           requires:
             - publish_docker_local
-      - codacy/sbt:
+      - codacy/shell:
           name: publish_dockerhub
           context: CodacyDocker
           cmd: |


### PR DESCRIPTION
When using the latest orb version `shell` should be used instead of `sbt` if the step doesn't require actual usage of sbt, otherwise it leads to issues with cache not being present which cause the step to fail.